### PR TITLE
Expose ManaItem on portable cells

### DIFF
--- a/common/src/main/java/appbot/AppliedBotanics.java
+++ b/common/src/main/java/appbot/AppliedBotanics.java
@@ -23,7 +23,7 @@ public interface AppliedBotanics {
 
     @ExpectPlatform
     static AppliedBotanics getInstance() {
-        throw new AssertionError();
+        return getInstance();
     }
 
     Lookup<IStorageMonitorableAccessor, Direction> meStorage(ServerLevel level, BlockPos pos);

--- a/common/src/main/java/appbot/ae2/MEStorageManaItem.java
+++ b/common/src/main/java/appbot/ae2/MEStorageManaItem.java
@@ -1,0 +1,99 @@
+package appbot.ae2;
+
+import com.google.common.primitives.Ints;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.BlockEntity;
+
+import vazkii.botania.api.mana.ManaItem;
+
+import appeng.api.config.Actionable;
+import appeng.api.networking.energy.IEnergySource;
+import appeng.api.networking.security.IActionSource;
+import appeng.api.storage.StorageCells;
+import appeng.api.storage.StorageHelper;
+import appeng.api.storage.cells.StorageCell;
+import appeng.items.tools.powered.AbstractPortableCell;
+
+public class MEStorageManaItem implements ManaItem {
+
+    private final StorageCell storage;
+    private final IEnergySource energy;
+    private final IActionSource source;
+
+    public MEStorageManaItem(StorageCell storage, IEnergySource energy, IActionSource source) {
+        this.storage = storage;
+        this.energy = energy;
+        this.source = source;
+    }
+
+    @Nullable
+    public static ManaItem forPortable(ItemStack stack) {
+        if (!(stack.getItem()instanceof AbstractPortableCell item)) {
+            return null;
+        }
+
+        var storage = StorageCells.getCellInventory(stack, null);
+
+        if (storage == null) {
+            return null;
+        }
+
+        return new MEStorageManaItem(storage, (amount, mode, multiplier) -> {
+            amount = multiplier.multiply(amount);
+
+            if (mode == Actionable.SIMULATE) {
+                return multiplier.divide(Math.min(amount, item.getAECurrentPower(stack)));
+            }
+
+            return multiplier.divide(item.extractAEPower(stack, amount, Actionable.MODULATE));
+        }, IActionSource.empty());
+    }
+
+    @Override
+    public int getMana() {
+        return (int) storage.extract(ManaKey.KEY, Integer.MAX_VALUE, Actionable.SIMULATE, source);
+    }
+
+    @Override
+    public int getMaxMana() {
+        return Ints.saturatedCast(storage.extract(ManaKey.KEY, Integer.MAX_VALUE, Actionable.SIMULATE, source)
+                + storage.insert(ManaKey.KEY, Integer.MAX_VALUE, Actionable.SIMULATE, source));
+    }
+
+    @Override
+    public void addMana(int mana) {
+        if (mana > 0) {
+            StorageHelper.poweredInsert(energy, storage, ManaKey.KEY, mana, source);
+        } else {
+            StorageHelper.poweredExtraction(energy, storage, ManaKey.KEY, -mana, source);
+        }
+    }
+
+    @Override
+    public boolean canReceiveManaFromPool(BlockEntity pool) {
+        return true;
+    }
+
+    @Override
+    public boolean canReceiveManaFromItem(ItemStack otherStack) {
+        return true;
+    }
+
+    @Override
+    public boolean canExportManaToPool(BlockEntity pool) {
+        return true;
+    }
+
+    @Override
+    public boolean canExportManaToItem(ItemStack otherStack) {
+        return true;
+    }
+
+    @Override
+    public boolean isNoExport() {
+        return false;
+    }
+}

--- a/common/src/main/java/appbot/item/cell/ManaCellInventory.java
+++ b/common/src/main/java/appbot/item/cell/ManaCellInventory.java
@@ -1,7 +1,8 @@
 package appbot.item.cell;
 
+import org.jetbrains.annotations.Nullable;
+
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
 
@@ -22,38 +23,17 @@ public class ManaCellInventory implements StorageCell {
 
     private final IManaCellItem cellType;
     private final ItemStack i;
+    @Nullable
     private final ISaveProvider container;
 
     private long storedMana;
     private boolean isPersisted = true;
 
-    public ManaCellInventory(IManaCellItem cellType, ItemStack o, ISaveProvider container) {
+    public ManaCellInventory(IManaCellItem cellType, ItemStack o, @Nullable ISaveProvider container) {
         this.cellType = cellType;
         this.i = o;
         this.container = container;
-
         this.storedMana = getTag().getLong(AMOUNT);
-
-        // Only migration for <=1.19.2 releases
-        var ITEM_COUNT_TAG = "ic";
-        var STACK_KEYS = "keys";
-        var STACK_AMOUNTS = "amts";
-
-        if (getTag().contains(ITEM_COUNT_TAG)) {
-            var amounts = getTag().getLongArray(STACK_AMOUNTS);
-            var tags = getTag().getList(STACK_KEYS, Tag.TAG_COMPOUND);
-
-            for (var i = 0; i < amounts.length; i++) {
-                if (AEKey.fromTagGeneric(tags.getCompound(i)) == ManaKey.KEY) {
-                    this.storedMana += amounts[i];
-                }
-            }
-
-            getTag().remove(ITEM_COUNT_TAG);
-            getTag().remove(STACK_KEYS);
-            getTag().remove(STACK_AMOUNTS);
-            saveChanges();
-        }
     }
 
     private CompoundTag getTag() {

--- a/fabric/src/main/java/appbot/fabric/ABItems.java
+++ b/fabric/src/main/java/appbot/fabric/ABItems.java
@@ -102,10 +102,8 @@ public class ABItems {
 
             Upgrades.add(AEItems.ENERGY_CARD, portable, 2, GuiText.PortableCells.getTranslationKey());
 
-            String path1 = "block/drive/cells/" + Registry.ITEM.getKey(cell).getPath();
-            StorageCellModels.registerModel(cell, id(path1));
-            String path = "block/drive/cells/" + Registry.ITEM.getKey(cell).getPath();
-            StorageCellModels.registerModel(portable, id(path));
+            StorageCellModels.registerModel(cell, id("block/drive/cells/" + Registry.ITEM.getKey(cell).getPath()));
+            StorageCellModels.registerModel(portable, id("block/drive/cells/" + Registry.ITEM.getKey(cell).getPath()));
         }
     }
 

--- a/fabric/src/main/java/appbot/fabric/AppliedBotanicsFabric.java
+++ b/fabric/src/main/java/appbot/fabric/AppliedBotanicsFabric.java
@@ -94,5 +94,9 @@ public interface AppliedBotanicsFabric {
                 });
             }
         });
+
+        BotaniaFabricCapabilities.MANA_ITEM.registerFallback((stack, context) -> {
+            return MEStorageManaItem.forPortable(stack);
+        });
     }
 }

--- a/fabric/src/main/java/appbot/fabric/AppliedBotanicsFabric.java
+++ b/fabric/src/main/java/appbot/fabric/AppliedBotanicsFabric.java
@@ -96,7 +96,7 @@ public interface AppliedBotanicsFabric {
         });
 
         BotaniaFabricCapabilities.MANA_ITEM.registerFallback((stack, context) -> {
-            return MEStorageManaItem.forPortable(stack);
+            return MEStorageManaItem.forItem(stack);
         });
     }
 }

--- a/forge/src/main/java/appbot/forge/AppliedBotanicsForge.java
+++ b/forge/src/main/java/appbot/forge/AppliedBotanicsForge.java
@@ -5,6 +5,7 @@ import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.core.Direction;
 import net.minecraft.core.Registry;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.MinecraftForge;
@@ -83,6 +84,23 @@ public class AppliedBotanicsForge {
                     return LazyOptional.empty();
                 }
             });
+        });
+        MinecraftForge.EVENT_BUS.addGenericListener(ItemStack.class, (AttachCapabilitiesEvent<ItemStack> event) -> {
+            var item = MEStorageManaItem.forPortable(event.getObject());
+
+            if (item != null) {
+                event.addCapability(AppliedBotanics.id("mana_item"), new ICapabilityProvider() {
+                    @Override
+                    public @NotNull <T> LazyOptional<T> getCapability(@NotNull Capability<T> capability,
+                            @Nullable Direction arg) {
+                        if (capability == BotaniaForgeCapabilities.MANA_ITEM) {
+                            return LazyOptional.of(() -> item).cast();
+                        }
+
+                        return LazyOptional.empty();
+                    }
+                });
+            }
         });
 
         StackWorldBehaviors.registerImportStrategy(ManaKeyType.TYPE, ManaStorageImportStrategy::new);

--- a/forge/src/main/java/appbot/forge/AppliedBotanicsForge.java
+++ b/forge/src/main/java/appbot/forge/AppliedBotanicsForge.java
@@ -86,7 +86,7 @@ public class AppliedBotanicsForge {
             });
         });
         MinecraftForge.EVENT_BUS.addGenericListener(ItemStack.class, (AttachCapabilitiesEvent<ItemStack> event) -> {
-            var item = MEStorageManaItem.forPortable(event.getObject());
+            var item = MEStorageManaItem.forItem(event.getObject());
 
             if (item != null) {
                 event.addCapability(AppliedBotanics.id("mana_item"), new ICapabilityProvider() {


### PR DESCRIPTION
Essentially makes portable Mana cells act like Mana tablets. Works with in-inventory items which consume Mana too.

![](https://media.discordapp.net/attachments/922829733132124200/1156525537213288488/2023-09-27_19.39.22.png)

