### PR TITLE
Rewrite Mana P2P to transfer only bursts

### DIFF
--- a/src/main/java/appbot/ABItems.java
+++ b/src/main/java/appbot/ABItems.java
@@ -22,7 +22,6 @@ import appeng.api.implementations.items.IAEItemPowerStorage;
 import appeng.api.parts.PartModels;
 import appeng.core.definitions.AEItems;
 import appeng.items.parts.PartItem;
-import appeng.items.parts.PartModelsHelper;
 
 public class ABItems {
 
@@ -76,7 +75,7 @@ public class ABItems {
                     256, 2.5));
 
     public static final DeferredItem<PartItem<ManaP2PTunnelPart>> MANA_P2P_TUNNEL = Util.make(() -> {
-        PartModels.registerModels(PartModelsHelper.createModels(ManaP2PTunnelPart.class));
+        PartModels.registerModels(ManaP2PTunnelPart.getModels().stream().flatMap(x -> x.getModels().stream()).toList());
         return ITEMS.register("mana_p2p_tunnel",
                 () -> new PartItem<>(new Item.Properties(), ManaP2PTunnelPart.class, ManaP2PTunnelPart::new));
     });

--- a/src/main/java/appbot/AppliedBotanicsForge.java
+++ b/src/main/java/appbot/AppliedBotanicsForge.java
@@ -77,9 +77,7 @@ public class AppliedBotanicsForge {
         });
         bus.addListener(EventPriority.LOWEST, this::registerGenericAdapters);
         bus.addListener((RegisterPartCapabilitiesEvent event) -> {
-            event.register(BotaniaForgeCapabilities.MANA_RECEIVER, (object, context) -> object.getExposedApi(),
-                    ManaP2PTunnelPart.class);
-            event.register(BotaniaForgeCapabilities.SPARK_ATTACHABLE, (object, context) -> object.getSparkAttachable(),
+            event.register(BotaniaForgeCapabilities.MANA_RECEIVER, (object, context) -> object,
                     ManaP2PTunnelPart.class);
         });
 

--- a/src/main/java/appbot/ae2/ManaContainerItemStrategy.java
+++ b/src/main/java/appbot/ae2/ManaContainerItemStrategy.java
@@ -20,10 +20,6 @@ public class ManaContainerItemStrategy implements ContainerItemStrategy<ManaKey,
 
     @Override
     public @Nullable GenericStack getContainedStack(ItemStack stack) {
-        if (stack.isEmpty()) {
-            return null;
-        }
-
         var item = XplatAbstractions.INSTANCE.findManaItem(stack);
 
         if (item != null) {

--- a/src/main/java/appbot/ae2/ManaP2PTunnelPart.java
+++ b/src/main/java/appbot/ae2/ManaP2PTunnelPart.java
@@ -1,42 +1,66 @@
 package appbot.ae2;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
-import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnknownNullability;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.item.ItemStack;
+import net.minecraft.core.Direction;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.util.FastColor;
+import net.minecraft.util.Mth;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
 
 import appbot.AppliedBotanics;
-import vazkii.botania.api.BotaniaForgeCapabilities;
-import vazkii.botania.api.mana.ManaPool;
 import vazkii.botania.api.mana.ManaReceiver;
-import vazkii.botania.api.mana.spark.SparkAttachable;
+import vazkii.botania.common.entity.BotaniaEntities;
+import vazkii.botania.common.entity.ManaBurstEntity;
+import vazkii.botania.common.handler.BotaniaSounds;
 
 import appeng.api.config.Actionable;
+import appeng.api.config.PowerMultiplier;
 import appeng.api.parts.IPartItem;
 import appeng.api.parts.IPartModel;
-import appeng.items.parts.PartModels;
-import appeng.parts.p2p.CapabilityP2PTunnelPart;
+import appeng.core.AEConfig;
+import appeng.parts.AEBasePart;
 import appeng.parts.p2p.P2PModels;
+import appeng.parts.p2p.P2PTunnelPart;
 
-public class ManaP2PTunnelPart extends CapabilityP2PTunnelPart<ManaP2PTunnelPart, ManaReceiver> {
+public class ManaP2PTunnelPart extends P2PTunnelPart<ManaP2PTunnelPart> implements ManaReceiver {
 
+    private static final double MANA_RETAINED = 0.95;
+    private static final int EXTRA_TICKS_EXISTED = 1;
+
+    private static final float[] ROTX, ROTY;
     private static final P2PModels MODELS = new P2PModels(AppliedBotanics.id("part/mana_p2p_tunnel"));
-    private final SparkAttachable sparkAttachable = new P2PSparkAttachable();
 
-    public ManaP2PTunnelPart(IPartItem<?> partItem) {
-        super(partItem, BotaniaForgeCapabilities.MANA_RECEIVER);
-        inputHandler = new InputHandler();
-        emptyHandler = new EmptyHandler();
+    static {
+        ROTX = new float[6];
+        ROTY = new float[6];
+
+        ROTY[Direction.DOWN.get3DDataValue()] = -90;
+        ROTY[Direction.UP.get3DDataValue()] = 90;
+
+        ROTX[Direction.DOWN.get3DDataValue()] = -90;
+        ROTX[Direction.UP.get3DDataValue()] = -90;
+        ROTX[Direction.NORTH.get3DDataValue()] = 0;
+        ROTX[Direction.SOUTH.get3DDataValue()] = -180;
+        ROTX[Direction.WEST.get3DDataValue()] = -90;
+        ROTX[Direction.EAST.get3DDataValue()] = -270;
     }
 
-    @PartModels
+    public ManaP2PTunnelPart(IPartItem<?> partItem) {
+        super(partItem);
+    }
+
     public static List<IPartModel> getModels() {
         return MODELS.getModels();
+    }
+
+    @Override
+    protected float getPowerDrainPerTick() {
+        return 2.0f;
     }
 
     @Override
@@ -44,190 +68,90 @@ public class ManaP2PTunnelPart extends CapabilityP2PTunnelPart<ManaP2PTunnelPart
         return MODELS.getModel(this.isPowered(), this.isActive());
     }
 
-    @Nullable
-    public SparkAttachable getSparkAttachable() {
-        return isOutput() ? null : sparkAttachable;
+    // <editor-fold desc="Fake ManaReceiver">
+    @Override
+    public @UnknownNullability Level getManaReceiverLevel() {
+        return getLevel();
     }
 
-    private class P2PSparkAttachable implements SparkAttachable {
-
-        @Override
-        public boolean canAttachSpark(ItemStack stack) {
-            return true;
-        }
-
-        @Override
-        public int getAvailableSpaceForMana() {
-            var space = 0;
-
-            for (var output : getOutputs()) {
-                try (var guard = output.getAdjacentCapability()) {
-                    var receiver = guard.get();
-                    space += ManaHelper.getCapacity(receiver);
-                }
-            }
-
-            return space;
-        }
-
-        @Override
-        public boolean areIncomingTransfersDone() {
-            for (var output : getOutputs()) {
-                try (var guard = output.getAdjacentCapability()) {
-                    var receiver = guard.get();
-
-                    if (receiver.canReceiveManaFromBursts() && !receiver.isFull()) {
-                        return true;
-                    }
-                }
-            }
-
-            return false;
-        }
+    @Override
+    public BlockPos getManaReceiverPos() {
+        return getBlockEntity().getBlockPos();
     }
 
-    private class InputHandler implements ManaReceiver, ManaPool, SafeMana {
-
-        @Override
-        public Level getManaReceiverLevel() {
-            return getLevel();
-        }
-
-        @Override
-        public BlockPos getManaReceiverPos() {
-            return getHost().getLocation().getPos();
-        }
-
-        @Override
-        public int getCurrentMana() {
-            return 0;
-        }
-
-        @Override
-        public boolean isFull() {
-            for (var output : getOutputs()) {
-                try (var guard = output.getAdjacentCapability()) {
-                    if (!guard.get().isFull()) {
-                        return false;
-                    }
-                }
-            }
-
-            return true;
-        }
-
-        @Override
-        public void receiveMana(int mana) {
-            if (mana <= 0) {
-                // if mana < 0, they're getting free mana...
-                return;
-            }
-
-            var outputs = getOutputStream()
-                    .filter(part -> {
-                        try (var guard = part.getAdjacentCapability()) {
-                            var receiver = guard.get();
-                            return receiver.canReceiveManaFromBursts() && !receiver.isFull();
-                        }
-                    })
-                    .collect(Collectors.toList());
-
-            if (outputs.isEmpty()) {
-                return;
-            }
-
-            Collections.shuffle(outputs);
-
-            deductTransportCost(mana / 100, ManaKeyType.TYPE);
-            var manaForEach = mana / outputs.size();
-            var spill = mana % outputs.size();
-
-            for (var output : outputs) {
-                try (var guard = output.getAdjacentCapability()) {
-                    guard.get().receiveMana(manaForEach + (spill-- > 0 ? 1 : 0));
-                }
-            }
-        }
-
-        @Override
-        public boolean canReceiveManaFromBursts() {
-            for (var output : getOutputs()) {
-                try (var guard = output.getAdjacentCapability()) {
-                    var result = guard.get();
-
-                    if (result.canReceiveManaFromBursts()) {
-                        return true;
-                    }
-                }
-            }
-
-            return false;
-        }
-
-        @Override
-        public boolean isOutputtingPower() {
-            return false;
-        }
-
-        @Override
-        public int getMaxMana() {
-            return getOutputStream()
-                    .map(part -> {
-                        try (var guard = part.getAdjacentCapability()) {
-                            return ManaHelper.getCapacity(guard.get());
-                        }
-                    })
-                    .reduce(0, Integer::sum);
-        }
-
-        @Override
-        public int insert(int amount, Actionable mode) {
-            var inserted = 0;
-
-            for (var output : getOutputs()) {
-                try (var guard = output.getAdjacentCapability()) {
-                    inserted += SafeMana.conv(guard.get()).insert(amount - inserted, mode);
-                }
-            }
-
-            return inserted;
-        }
-
-        @Override
-        public int extract(int amount, Actionable mode) {
-            return 0;
-        }
+    @Override
+    public int getCurrentMana() {
+        return 0;
     }
 
-    private class EmptyHandler implements ManaReceiver {
+    @Override
+    public boolean isFull() {
+        return !isActive() || isOutput() || getOutputStream().noneMatch(AEBasePart::isActive);
+    }
 
-        @Override
-        public Level getManaReceiverLevel() {
-            return getLevel();
+    @Override
+    public void receiveMana(int mana) {
+        // voids mana, we want bursts only
+    }
+
+    @Override
+    public boolean canReceiveManaFromBursts() {
+        return !isFull();
+    }
+    // </editor-fold>
+
+    public void receiveManaFromBurst(ManaBurstEntity burst) {
+        var node = getMainNode().getNode();
+        int mana = burst.getMana();
+
+        if (node == null || isFull() || mana <= 0) {
+            return;
         }
 
-        @Override
-        public BlockPos getManaReceiverPos() {
-            return getHost().getLocation().getPos();
+        var outputs = getOutputStream().filter(AEBasePart::isActive).toList();
+        if (outputs.isEmpty())
+            return;
+
+        var output = outputs.get(getLevel().getRandom().nextInt(outputs.size()));
+
+        var costFactor = AEConfig.instance().getP2PTunnelTransportTax();
+
+        if (costFactor > 0) {
+            var energised = node.getGrid().getEnergyService().extractAEPower(mana * costFactor, Actionable.MODULATE,
+                    PowerMultiplier.ONE) / costFactor;
+            mana = (int) (energised * MANA_RETAINED);
+        } else {
+            mana = (int) (mana * MANA_RETAINED);
         }
 
-        @Override
-        public int getCurrentMana() {
-            return 0;
+        if (mana <= 0) {
+            return;
         }
 
-        @Override
-        public boolean isFull() {
-            return true;
-        }
+        var level = output.getLevel();
+        var dir = output.getSide();
+        var pos = output.getBlockEntity().getBlockPos();
 
-        @Override
-        public void receiveMana(int mana) {
-        }
+        int old = burst.getColor();
+        int rainbow = Mth.hsvToRgb(level.getGameTime() * 2 % 360 / 360F, 1F, 1F);
+        int newColor = FastColor.ARGB32.lerp(0.4f, old, rainbow);
 
-        @Override
-        public boolean canReceiveManaFromBursts() {
-            return false;
-        }
+        var newBurst = new ManaBurstEntity(BotaniaEntities.MANA_BURST, level);
+        var at = Vec3.atCenterOf(pos).add(Vec3.atLowerCornerOf(dir.getNormal()).scale(0.5));
+        newBurst.moveTo(at.x, at.y, at.z, ROTX[dir.get3DDataValue()], ROTY[dir.get3DDataValue()]);
+        newBurst.setDeltaMovement(ManaBurstEntity.calculateBurstVelocity(newBurst.getXRot(), newBurst.getYRot()));
+        newBurst.setColor(newColor);
+        newBurst.setMana(mana);
+        newBurst.setStartingMana(burst.getStartingMana());
+        newBurst.setMinManaLoss(burst.getMinManaLoss());
+        newBurst.setManaLossPerTick(burst.getManaLossPerTick());
+        newBurst.setGravity(burst.getBurstGravity());
+        burst.getBurstSourcePosition().ifPresent(newBurst::setBurstSourcePosition);
+        newBurst.setSourceLens(burst.getSourceLens());
+        newBurst.setTicksExisted(burst.getTicksExisted() + ManaP2PTunnelPart.EXTRA_TICKS_EXISTED);
+
+        level.addFreshEntity(newBurst);
+        level.playSound(null, pos, BotaniaSounds.spreaderFire, SoundSource.BLOCKS, 0.05F,
+                0.7F + 0.3F * (float) Math.random());
     }
 }

--- a/src/main/java/appbot/ae2/ManaP2PTunnelPart.java
+++ b/src/main/java/appbot/ae2/ManaP2PTunnelPart.java
@@ -3,13 +3,18 @@ package appbot.ae2;
 import java.util.List;
 
 import org.jetbrains.annotations.UnknownNullability;
+import org.joml.Matrix3d;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.util.FastColor;
 import net.minecraft.util.Mth;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
 
 import appbot.AppliedBotanics;
@@ -20,35 +25,23 @@ import vazkii.botania.common.handler.BotaniaSounds;
 
 import appeng.api.config.Actionable;
 import appeng.api.config.PowerMultiplier;
+import appeng.api.orientation.BlockOrientation;
 import appeng.api.parts.IPartItem;
 import appeng.api.parts.IPartModel;
 import appeng.core.AEConfig;
 import appeng.parts.AEBasePart;
 import appeng.parts.p2p.P2PModels;
 import appeng.parts.p2p.P2PTunnelPart;
+import appeng.util.InteractionUtil;
 
-public class ManaP2PTunnelPart extends P2PTunnelPart<ManaP2PTunnelPart> implements ManaReceiver {
+public class ManaP2PTunnelPart extends P2PTunnelPart<ManaP2PTunnelPart> implements ManaReceiver, SafeMana {
 
     private static final double MANA_RETAINED = 0.95;
     private static final int EXTRA_TICKS_EXISTED = 1;
 
-    private static final float[] ROTX, ROTY;
     private static final P2PModels MODELS = new P2PModels(AppliedBotanics.id("part/mana_p2p_tunnel"));
 
-    static {
-        ROTX = new float[6];
-        ROTY = new float[6];
-
-        ROTY[Direction.DOWN.get3DDataValue()] = -90;
-        ROTY[Direction.UP.get3DDataValue()] = 90;
-
-        ROTX[Direction.DOWN.get3DDataValue()] = -90;
-        ROTX[Direction.UP.get3DDataValue()] = -90;
-        ROTX[Direction.NORTH.get3DDataValue()] = 0;
-        ROTX[Direction.SOUTH.get3DDataValue()] = -180;
-        ROTX[Direction.WEST.get3DDataValue()] = -90;
-        ROTX[Direction.EAST.get3DDataValue()] = -270;
-    }
+    private byte spin;
 
     public ManaP2PTunnelPart(IPartItem<?> partItem) {
         super(partItem);
@@ -66,6 +59,41 @@ public class ManaP2PTunnelPart extends P2PTunnelPart<ManaP2PTunnelPart> implemen
     @Override
     public IPartModel getStaticModels() {
         return MODELS.getModel(this.isPowered(), this.isActive());
+    }
+
+    @Override
+    public void readFromNBT(CompoundTag data, HolderLookup.Provider registries) {
+        super.readFromNBT(data, registries);
+        spin = data.getByte("spin");
+    }
+
+    @Override
+    public void writeToNBT(CompoundTag data, HolderLookup.Provider registries) {
+        super.writeToNBT(data, registries);
+        data.putByte("spin", spin);
+    }
+
+    @Override
+    public boolean onUseWithoutItem(Player player, Vec3 pos) {
+        if (InteractionUtil.canWrenchRotate(player.getInventory().getSelected())) {
+            if (!isClientSide()) {
+                this.spin = (byte) ((this.spin + 1) % 4);
+                this.getHost().markForUpdate();
+                this.getHost().markForSave();
+            }
+            return true;
+        } else {
+            return super.onUseWithoutItem(player, pos);
+        }
+    }
+
+    @Override
+    public void onPlacement(Player player) {
+        super.onPlacement(player);
+
+        if (getSide().getAxis() == Direction.Axis.Y) {
+            this.spin = (byte) (Mth.floor(player.getYRot() * 4F / 360F + 2.5D) & 3);
+        }
     }
 
     // <editor-fold desc="Fake ManaReceiver">
@@ -98,11 +126,21 @@ public class ManaP2PTunnelPart extends P2PTunnelPart<ManaP2PTunnelPart> implemen
     public boolean canReceiveManaFromBursts() {
         return !isFull();
     }
+
+    @Override
+    public int insert(int amount, Actionable mode) {
+        return 0;
+    }
+
+    @Override
+    public int extract(int amount, Actionable mode) {
+        return 0;
+    }
     // </editor-fold>
 
-    public void receiveManaFromBurst(ManaBurstEntity burst) {
+    public void receiveManaFromBurst(ManaBurstEntity burst, BlockHitResult hit) {
         var node = getMainNode().getNode();
-        int mana = burst.getMana();
+        var mana = burst.getMana();
 
         if (node == null || isFull() || mana <= 0) {
             return;
@@ -112,7 +150,31 @@ public class ManaP2PTunnelPart extends P2PTunnelPart<ManaP2PTunnelPart> implemen
         if (outputs.isEmpty())
             return;
 
+        var input = this;
         var output = outputs.get(getLevel().getRandom().nextInt(outputs.size()));
+
+        Vec3 moveTo, directionTo;
+        float xrot, yrot;
+
+        {
+            var sideInput = input.getSide();
+            var sideOutput = output.getSide();
+
+            var originInput = Vec3.atCenterOf(input.getBlockEntity().getBlockPos())
+                    .add(Vec3.atLowerCornerOf(sideInput.getNormal()).scale(0.5)).toVector3f();
+            var originOutput = Vec3.atCenterOf(output.getBlockEntity().getBlockPos())
+                    .add(Vec3.atLowerCornerOf(sideOutput.getNormal()).scale(0.5)).toVector3f();
+
+            var r = onb(sideOutput, output.getOrientation())
+                    .mul(onb(sideInput, input.getOrientation()).transpose());
+
+            moveTo = new Vec3(hit.getLocation().toVector3f().sub(originInput).mul(r).add(originOutput));
+            directionTo = new Vec3(burst.getDeltaMovement().toVector3f().mul(r)).scale(-1);
+
+            var xz = Math.sqrt(directionTo.x * directionTo.x + directionTo.z * directionTo.z);
+            xrot = Mth.wrapDegrees((float) -(Mth.atan2(directionTo.y, xz) * Mth.RAD_TO_DEG));
+            yrot = Mth.wrapDegrees((float) (Mth.atan2(directionTo.z, directionTo.x) * Mth.RAD_TO_DEG) - 90.0F);
+        }
 
         var costFactor = AEConfig.instance().getP2PTunnelTransportTax();
 
@@ -129,17 +191,14 @@ public class ManaP2PTunnelPart extends P2PTunnelPart<ManaP2PTunnelPart> implemen
         }
 
         var level = output.getLevel();
-        var dir = output.getSide();
-        var pos = output.getBlockEntity().getBlockPos();
 
-        int old = burst.getColor();
-        int rainbow = Mth.hsvToRgb(level.getGameTime() * 2 % 360 / 360F, 1F, 1F);
-        int newColor = FastColor.ARGB32.lerp(0.4f, old, rainbow);
+        var old = burst.getColor();
+        var rainbow = Mth.hsvToRgb(level.getGameTime() * 2 % 360 / 360F, 1F, 1F);
+        var newColor = FastColor.ARGB32.lerp(0.4f, old, rainbow);
 
         var newBurst = new ManaBurstEntity(BotaniaEntities.MANA_BURST, level);
-        var at = Vec3.atCenterOf(pos).add(Vec3.atLowerCornerOf(dir.getNormal()).scale(0.5));
-        newBurst.moveTo(at.x, at.y, at.z, ROTX[dir.get3DDataValue()], ROTY[dir.get3DDataValue()]);
-        newBurst.setDeltaMovement(ManaBurstEntity.calculateBurstVelocity(newBurst.getXRot(), newBurst.getYRot()));
+        newBurst.moveTo(moveTo.x, moveTo.y, moveTo.z, yrot, xrot);
+        newBurst.setDeltaMovement(directionTo);
         newBurst.setColor(newColor);
         newBurst.setMana(mana);
         newBurst.setStartingMana(burst.getStartingMana());
@@ -151,7 +210,28 @@ public class ManaP2PTunnelPart extends P2PTunnelPart<ManaP2PTunnelPart> implemen
         newBurst.setTicksExisted(burst.getTicksExisted() + ManaP2PTunnelPart.EXTRA_TICKS_EXISTED);
 
         level.addFreshEntity(newBurst);
-        level.playSound(null, pos, BotaniaSounds.spreaderFire, SoundSource.BLOCKS, 0.05F,
+        level.playSound(null, moveTo.x, moveTo.y, moveTo.z, BotaniaSounds.spreaderFire, SoundSource.BLOCKS, 0.05F,
                 0.7F + 0.3F * (float) Math.random());
+    }
+
+    private static Matrix3d onb(Direction a, Direction b) {
+        var m = new Matrix3d();
+        var va = a.getNormal();
+        var vb = b.getNormal();
+        var vc = va.cross(vb);
+        m.m00 = va.getX();
+        m.m01 = va.getY();
+        m.m02 = va.getZ();
+        m.m10 = vb.getX();
+        m.m11 = vb.getY();
+        m.m12 = vb.getZ();
+        m.m20 = vc.getX();
+        m.m21 = vc.getY();
+        m.m22 = vc.getZ();
+        return m;
+    }
+
+    private Direction getOrientation() {
+        return BlockOrientation.get(getSide(), spin).rotate(Direction.UP);
     }
 }

--- a/src/main/java/appbot/ae2/ManaP2PTunnelPart.java
+++ b/src/main/java/appbot/ae2/ManaP2PTunnelPart.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.jetbrains.annotations.UnknownNullability;
 import org.joml.Matrix3d;
+import org.joml.Vector3f;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -157,16 +158,11 @@ public class ManaP2PTunnelPart extends P2PTunnelPart<ManaP2PTunnelPart> implemen
         float xrot, yrot;
 
         {
-            var sideInput = input.getSide();
-            var sideOutput = output.getSide();
+            var originInput = getFaceCentre(input.getBlockEntity().getBlockPos(), input.getSide());
+            var originOutput = getFaceCentre(output.getBlockEntity().getBlockPos(), output.getSide());
 
-            var originInput = Vec3.atCenterOf(input.getBlockEntity().getBlockPos())
-                    .add(Vec3.atLowerCornerOf(sideInput.getNormal()).scale(0.5)).toVector3f();
-            var originOutput = Vec3.atCenterOf(output.getBlockEntity().getBlockPos())
-                    .add(Vec3.atLowerCornerOf(sideOutput.getNormal()).scale(0.5)).toVector3f();
-
-            var r = onb(sideOutput, output.getOrientation())
-                    .mul(onb(sideInput, input.getOrientation()).transpose());
+            var r = onb(output.getSide(), output.getOrientation())
+                    .mul(onb(input.getSide(), input.getOrientation()).transpose());
 
             moveTo = new Vec3(hit.getLocation().toVector3f().sub(originInput).mul(r).add(originOutput));
             directionTo = new Vec3(burst.getDeltaMovement().toVector3f().mul(r)).scale(-1);
@@ -208,10 +204,16 @@ public class ManaP2PTunnelPart extends P2PTunnelPart<ManaP2PTunnelPart> implemen
         burst.getBurstSourcePosition().ifPresent(newBurst::setBurstSourcePosition);
         newBurst.setSourceLens(burst.getSourceLens());
         newBurst.setTicksExisted(burst.getTicksExisted() + ManaP2PTunnelPart.EXTRA_TICKS_EXISTED);
+        newBurst.setShooterUUID(burst.getShooterUUID());
 
         level.addFreshEntity(newBurst);
         level.playSound(null, moveTo.x, moveTo.y, moveTo.z, BotaniaSounds.spreaderFire, SoundSource.BLOCKS, 0.05F,
                 0.7F + 0.3F * (float) Math.random());
+    }
+
+    private static Vector3f getFaceCentre(BlockPos pos, Direction dir) {
+        return new Vector3f(pos.getX() + (float) (1 + dir.getStepX()) / 2,
+                pos.getY() + (float) (1 + dir.getStepY()) / 2, pos.getZ() + (float) (1 + dir.getStepZ()) / 2);
     }
 
     private static Matrix3d onb(Direction a, Direction b) {

--- a/src/main/java/appbot/item/cell/ManaCellHandler.java
+++ b/src/main/java/appbot/item/cell/ManaCellHandler.java
@@ -16,7 +16,7 @@ public class ManaCellHandler implements ICellHandler {
 
     @Override
     public boolean isCell(ItemStack is) {
-        return !is.isEmpty() && is.getItem() instanceof IManaCellItem;
+        return is.getItem() instanceof IManaCellItem;
     }
 
     @Nullable

--- a/src/main/java/appbot/mixins/BotaniaBlockEntitiesMixin.java
+++ b/src/main/java/appbot/mixins/BotaniaBlockEntitiesMixin.java
@@ -16,7 +16,7 @@ import vazkii.botania.api.BotaniaAPI;
 import vazkii.botania.common.block.block_entity.BotaniaBlockEntities;
 import vazkii.botania.common.lib.LibBlockNames;
 
-@Mixin(value = BotaniaBlockEntities.class, remap = false)
+@Mixin(value = BotaniaBlockEntities.class)
 public abstract class BotaniaBlockEntitiesMixin {
 
     @ModifyVariable(method = "type(Lnet/minecraft/resources/ResourceLocation;Lnet/minecraft/world/level/block/entity/BlockEntityType$BlockEntitySupplier;[Lnet/minecraft/world/level/block/Block;)Lnet/minecraft/world/level/block/entity/BlockEntityType;", at = @At("HEAD"), index = 1, argsOnly = true)

--- a/src/main/java/appbot/mixins/BotaniaBlockEntitiesMixin.java
+++ b/src/main/java/appbot/mixins/BotaniaBlockEntitiesMixin.java
@@ -16,7 +16,7 @@ import vazkii.botania.api.BotaniaAPI;
 import vazkii.botania.common.block.block_entity.BotaniaBlockEntities;
 import vazkii.botania.common.lib.LibBlockNames;
 
-@Mixin(value = BotaniaBlockEntities.class)
+@Mixin(BotaniaBlockEntities.class)
 public abstract class BotaniaBlockEntitiesMixin {
 
     @ModifyVariable(method = "type(Lnet/minecraft/resources/ResourceLocation;Lnet/minecraft/world/level/block/entity/BlockEntityType$BlockEntitySupplier;[Lnet/minecraft/world/level/block/Block;)Lnet/minecraft/world/level/block/entity/BlockEntityType;", at = @At("HEAD"), index = 1, argsOnly = true)

--- a/src/main/java/appbot/mixins/InteractionUtilMixin.java
+++ b/src/main/java/appbot/mixins/InteractionUtilMixin.java
@@ -1,0 +1,24 @@
+package appbot.mixins;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.world.item.ItemStack;
+
+import vazkii.botania.common.item.WandOfTheForestItem;
+
+import appeng.util.InteractionUtil;
+
+@Mixin(InteractionUtil.class)
+public class InteractionUtilMixin {
+
+    @Inject(method = "canWrenchDisassemble", at = @At("HEAD"), cancellable = true)
+    private static void wandNotWrench(ItemStack tool, CallbackInfoReturnable<Boolean> cir) {
+        // make binding mana spreaders to p2p easier
+        if (WandOfTheForestItem.getBindMode(tool)) {
+            cir.setReturnValue(false);
+        }
+    }
+}

--- a/src/main/java/appbot/mixins/ManaBurstEntityMixin.java
+++ b/src/main/java/appbot/mixins/ManaBurstEntityMixin.java
@@ -1,9 +1,12 @@
 package appbot.mixins;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.world.phys.BlockHitResult;
 
 import appbot.ae2.ManaP2PTunnelPart;
 import vazkii.botania.api.mana.ManaReceiver;
@@ -12,11 +15,14 @@ import vazkii.botania.common.entity.ManaBurstEntity;
 @Mixin(ManaBurstEntity.class)
 public class ManaBurstEntityMixin {
 
-    @Inject(method = "onReceiverImpact", at = @At("HEAD"), cancellable = true)
-    private void onReceiverImpact(ManaReceiver receiver, CallbackInfoReturnable<Boolean> cir) {
-        if (receiver instanceof ManaP2PTunnelPart p2p) {
-            p2p.receiveManaFromBurst((ManaBurstEntity) (Object) this);
-            cir.setReturnValue(false);
+    @WrapOperation(method = "onHitBlock", at = @At(value = "INVOKE", target = "Lvazkii/botania/common/entity/ManaBurstEntity;onReceiverImpact(Lvazkii/botania/api/mana/ManaReceiver;)Z"))
+    private boolean onReceiverImpact(ManaBurstEntity instance, ManaReceiver collector, Operation<Boolean> original,
+            BlockHitResult hit) {
+        if (collector instanceof ManaP2PTunnelPart p2p) {
+            p2p.receiveManaFromBurst(instance, hit);
+            return false;
         }
+
+        return original.call(instance, collector);
     }
 }

--- a/src/main/java/appbot/mixins/ManaBurstEntityMixin.java
+++ b/src/main/java/appbot/mixins/ManaBurstEntityMixin.java
@@ -1,0 +1,22 @@
+package appbot.mixins;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import appbot.ae2.ManaP2PTunnelPart;
+import vazkii.botania.api.mana.ManaReceiver;
+import vazkii.botania.common.entity.ManaBurstEntity;
+
+@Mixin(ManaBurstEntity.class)
+public class ManaBurstEntityMixin {
+
+    @Inject(method = "onReceiverImpact", at = @At("HEAD"), cancellable = true)
+    private void onReceiverImpact(ManaReceiver receiver, CallbackInfoReturnable<Boolean> cir) {
+        if (receiver instanceof ManaP2PTunnelPart p2p) {
+            p2p.receiveManaFromBurst((ManaBurstEntity) (Object) this);
+            cir.setReturnValue(false);
+        }
+    }
+}

--- a/src/main/java/appbot/mixins/ManaPoolBlockEntityAccessor.java
+++ b/src/main/java/appbot/mixins/ManaPoolBlockEntityAccessor.java
@@ -5,7 +5,7 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 
 import vazkii.botania.common.block.block_entity.mana.ManaPoolBlockEntity;
 
-@Mixin(value = ManaPoolBlockEntity.class, remap = false)
+@Mixin(ManaPoolBlockEntity.class)
 public interface ManaPoolBlockEntityAccessor {
 
     @Accessor

--- a/src/main/resources/appbot.mixins.json
+++ b/src/main/resources/appbot.mixins.json
@@ -4,6 +4,8 @@
   "package": "appbot.mixins",
   "mixins": [
     "BotaniaBlockEntitiesMixin",
+    "InteractionUtilMixin",
+    "ManaBurstEntityMixin",
     "ManaPoolBlockEntityAccessor",
     "Pool",
     "TAPBE",


### PR DESCRIPTION
I'll be making a few changes to improve the balance of this mod.

This update will make the Mana P2P transfer only bursts, so you'll need a mana spreader on the input side. Lens effects like bore or potency velocity will carry through.

TODO: How to deal with things trying to deposit Mana directly without a burst (right now it just discards).
TODO: The input mana spreader doesn't ever stop, even if extra bursts wouldn't go anywhere. How to deal with that?